### PR TITLE
Fix the printing for matchers.

### DIFF
--- a/ditto/__init__.py
+++ b/ditto/__init__.py
@@ -330,8 +330,12 @@ class MockError(AssertionError):
       return self.expt_msg.format(
           method=exp.method.name,
           args=', '.join(
-            [repr(a) for a in exp.args] +
-            ['{k}={v!r}'.format(k=k, v=v) for k, v in exp.kwargs.items()]
+            ([repr(a) for a in exp.args]
+                if isinstance(exp.args, collections.Iterable)
+                    else ['*' + repr(exp.args)]) +
+            (['{k}={v!r}'.format(k=k, v=v) for k, v in exp.kwargs.items()]
+                if hasattr(exp.kwargs, 'items')
+                    else ['**' + repr(exp.kwargs)])
           ),
       )
 
@@ -433,6 +437,9 @@ class matches(object):
 
     def __eq__(self, other):
         return self.matcher.matches(other)
+
+    def __repr__(self):
+        return '<{0}>'.format(str(self.matcher))
 
     def __str__(self):
         return str(self.matcher)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='ditto',
-      version='1.2',
+      version='1.2.1',
       description='Python Class Mocking Framework',
       author='Kyle Derr',
       author_email='kyle.derr@gmail.com',


### PR DESCRIPTION
In a previous bump, I built a pretty print feature. That feature crashes
terribly when used with arg matchers (and the unit tests even caught it). This
patch fixes those crashes.
